### PR TITLE
fzsl: more robust default scanner

### DIFF
--- a/bin/fzsl
+++ b/bin/fzsl
@@ -59,7 +59,7 @@ def pick_scanner(scanners):
     cwd = os.getcwd()
     avail = [scanner for scanner in scanners if scanner.is_suitable(cwd)]
     if len(avail) == 0:
-        return fzsl.SimpleScanner('default', 'find .')
+        return fzsl.SimpleScanner('default', 'find -L . || true')
     else:
         return avail[0]
 

--- a/etc/fzsl.conf
+++ b/etc/fzsl.conf
@@ -10,7 +10,11 @@
 #
 # If no rules are considered suitable for the current working
 # directory, then a rule will be created that simply executes
-# 'find .'.
+# 'find -L . 2>/dev/null || true'. Note, 'find' will return an
+# non-zero status if all files are processed successfully. However
+# it is common to encounter files or directories with permission
+# issues. For a tool like fzsl it is desirable to be more
+# generous with the list of files and directories returned.
 
 # Scanner options:
 #
@@ -107,21 +111,21 @@ priority = 10
 #[linux]
 # type = simple
 #root_path = /usr/src/linux
-#cmd = find .
+#cmd = find -L . || true
 #cache = ~/.fzsl-cache/linux
 
 # Override the default by creating any rule that doesn't
 # have a root_path or detect_cmd.
 [default]
 type = simple
-cmd = find . -maxdepth 10
+cmd = find -L . -maxdepth 10 || true
 priority = 0
 
 # Rule that will only be used when specifically passed
 # via --rule to fzsl.
 [dirs-only]
 type = simple
-cmd = find . -type d
+cmd = find -L . -type d || true
 priority = -1
 
 # Example plugin file that loads the default simple scanner.


### PR DESCRIPTION
I encountered a problem when using fzsl from my home directory when it encountered paths that the 'find' command did not have permission to access. Because it was my home directory there was no special scanner specified so fzsl defaults to using find. I think that the default scanner should something that is pretty much fail-safe. So I have modified the form of the find command used with that in mind. In particular, a value of 'true' is returned if find 'fails' for any reason so that 'find' can never fail. I also added the -L option to the find to collect symlinked files, which a user may also want to select from.