### PR TITLE
Makefile targets and support for piped input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ virtualenv[23]*/
 build/
 fzsl.egg-info/
 dist/
+installed_files.txt

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,19 @@ all: virtualenv$(PYTHON_VERSION)
 
 dist: dist/fzsl-$(VERSION).tar.gz
 
+build:
+	python setup.py build
+
+install: build
+	sudo python setup.py install --record installed_files.txt
+
+uninstall:
+	@if [ -e "installed_files.txt" ]; then \
+		while read path; do \
+			echo $${path}; \
+			sudo rm -rf $${path}; \
+		done < "installed_files.txt"; \
+	fi
 
 virtualenv$(PYTHON_VERSION): requirements.txt
 	@$(VIRTUALENV) --python=python$(PYTHON_VERSION) virtualenv$(PYTHON_VERSION)

--- a/bin/fzsl
+++ b/bin/fzsl
@@ -89,33 +89,16 @@ def main():
 
     parser = read_config(config)
 
-    # Put stdin into a non-blocking mode
-    fd = sys.stdin.fileno()
-    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+    if not sys.stdin.isatty():
+        # Create a scanner that simply has the list of provided paths
+        paths = [p.strip().decode('UTF-8') for p in sys.stdin]
+        scanner = fzsl.StaticScanner(paths)
 
-    # If paths have been piped directly to the script, read them into a list and
-    # create a StaticScanner.
-    paths = ""
-    while True:
-        try:
-            path = os.read(fd, 1024)
-            if not path:
-                break
-            paths += path
-        except OSError:
-            break
-        except Exception:
-            continue
-
-    if paths:
         # If input is piped in via stdin ncurses will receive bad input and
         # crash. To avoid that, we reopen the terminal.
         f = open("/dev/tty")
         os.dup2(f.fileno(), 0)
 
-        # Create a scanner that simply has the list of provided paths
-        scanner = fzsl.StaticScanner(paths.splitlines())
     elif rule is None:
         scanners = build_scanners(parser)
         scanner = pick_scanner(scanners)

--- a/bin/fzsl
+++ b/bin/fzsl
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 
+import fcntl
 import getopt
 import os
 import sys
@@ -63,6 +64,7 @@ def pick_scanner(scanners):
     else:
         return avail[0]
 
+
 def main():
     try:
         opts, args = getopt.getopt(
@@ -86,7 +88,35 @@ def main():
             rule = a
 
     parser = read_config(config)
-    if rule is None:
+
+    # Put stdin into a non-blocking mode
+    fd = sys.stdin.fileno()
+    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+
+    # If paths have been piped directly to the script, read them into a list and
+    # create a StaticScanner.
+    paths = ""
+    while True:
+        try:
+            path = os.read(fd, 1024)
+            if not path:
+                break
+            paths += path
+        except OSError:
+            break
+        except Exception:
+            continue
+
+    if paths:
+        # If input is piped in via stdin ncurses will receive bad input and
+        # crash. To avoid that, we reopen the terminal.
+        f = open("/dev/tty")
+        os.dup2(f.fileno(), 0)
+
+        # Create a scanner that simply has the list of provided paths
+        scanner = fzsl.StaticScanner(paths.splitlines())
+    elif rule is None:
         scanners = build_scanners(parser)
         scanner = pick_scanner(scanners)
     else:

--- a/bin/fzsl
+++ b/bin/fzsl
@@ -20,7 +20,7 @@ __default_config_path__ = os.path.join(
 __usage__ = """
 fzsl [ARGUMENTS]
 
-Fuzzy Shell -  Launch a curses window to preform
+Fuzzy Shell -  Launch a curses window to perform
 fuzzy matching.
 
 ARGUMENTS:

--- a/fzsl/__init__.py
+++ b/fzsl/__init__.py
@@ -13,6 +13,7 @@ from . scanner import (
     Scanner,
     scanner_from_configparser,
     SimpleScanner,
+    StaticScanner,
     SubprocessError,
     UnknownTypeError,
 )

--- a/fzsl/scanner.py
+++ b/fzsl/scanner.py
@@ -234,6 +234,50 @@ class SimpleScanner(Scanner):
 
         return ret
 
+class StaticScanner(Scanner):
+    """
+    This class is used to provided a static list of paths. Another way of
+    viewing it is that the paths have been pre-scanned and this scanner simply
+    serves the result.
+    """
+
+    def __init__(self, paths):
+        """
+        Creates a StaticScanner
+
+        The StaticScanner contains a list of paths that it provides for
+        matching. Thus there is no really scanning and all paths are
+        automatically suitable.
+
+        @option paths - a list of paths to use for matching
+
+        """
+        self._paths = paths
+
+    def is_suitable(self, path):
+        """
+        Returns True if the path is suitable
+
+        For the StaticScanner, this function always returns True.
+
+        @option path - the path to evaluate
+        @return a boolean indicating whether the path is suitable
+
+        """
+        return True
+
+    def scan(self, path=None, rescan=False):
+        """
+        Scan the path for a list of files.
+
+        @param path     - ignore by the StaticScanner
+        @param rescan   - ignore by the StaticScanner
+        @return         - list of paths contained in the StaticScanner
+
+        """
+        return self._paths
+
+
 def plugin_scanner_from_configparser(section, parser):
     """
     Create a plugin scanner from a config parser section.  A plugin

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import os
 import setuptools
-import sys
 
 def read(*paths):
     """Build a file path from *paths* and return the contents."""


### PR DESCRIPTION
There are two main changes in this PR. The first, is the addition of 'build', 'install', and 'uninstall' targets to the makefile. The makefile invokes the setup.py script. However, separating the build and install of installation means that the build directory is not created as root if the user is trying to install to the system. There are other artifacts of the installation process that are created by root though so there is still more work to be done there.

The other change is to allow lists of paths to be piped into the fzsl script. The piped input is assume to be a list of paths to match against. A simple scanner is created that just provides the paths that were piped in.