### PR TITLE
Add a post match transformation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,10 @@ should be defined in *~/.bash_profile*::
     specified along with detect_cmd, then the root_path will be used as the
     current working directory when executing the detect_cmd.
 
+    To use the stdout of a command rather than a fixed string as the root_path,
+    preface the root_command with a **!**.  For example,::
+        root_path = !echo "my/root/path"
+
 **priority**
     The priority is used to determine which scanner to use when multiple
     scanners are considered suitable.  The higher the priority, the more likely

--- a/etc/fzsl.conf
+++ b/etc/fzsl.conf
@@ -91,6 +91,10 @@
 type = simple
 detect_cmd = git rev-parse
 cmd = git ls-files
+# The leading '!' means that the root_path is not a fixed string but
+# rather a command to be executed which will echo the root_path to
+# be used to stdout.
+root_path = !git rev-parse --show-toplevel
 # See git-ls-files(1) for other options like adding '-o' to
 # also include untracked files
 priority = 10

--- a/fzsl/scanner.py
+++ b/fzsl/scanner.py
@@ -70,6 +70,17 @@ class Scanner(object, six.with_metaclass(abc.ABCMeta)):
         """
         pass
 
+    def transform(self, path):
+        """
+        Final tranform for a path.  This can be used to present matches which
+        are more user-friendly during the selection process when can later be
+        transformed via this method into the required match.
+
+        @param path - path to be transformed
+        @return     - the transformed path
+        """
+        return path
+
 
 class SimpleScanner(Scanner):
     def __init__(self, name, cmd, priority=0, detect_cmd=None, root_path=None, cache=None):
@@ -249,6 +260,14 @@ class SimpleScanner(Scanner):
                     fp.write(u'\n'.join(ret))
 
         return ret
+
+    def transform(self, path):
+        if self._root_path:
+            root_rel_path = os.path.join(self._root_path, path)
+            return os.path.normpath(root_rel_path)
+        else:
+            return path
+
 
 class StaticScanner(Scanner):
     """

--- a/fzsl/scanner.py
+++ b/fzsl/scanner.py
@@ -106,10 +106,26 @@ class SimpleScanner(Scanner):
         self._cache = None
 
         if root_path is not None:
-            root_path = os.path.expandvars(root_path)
-            root_path = os.path.expanduser(root_path)
-            root_path = os.path.normpath(root_path)
-            self._root_path = os.path.realpath(root_path)
+            if root_path.startswith('!'):
+                try:
+                    c = subprocess.Popen(
+                            root_path[1:],
+                            shell=True,
+                            stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE)
+                    stdout, stderr = c.communicate()
+                except:
+                    raise SubprocessError(root_path[1:], os.path.realpath(os.curdir), stderr)
+
+                if c.returncode != 0:
+                    raise SubprocessError(root_path[1:], os.path.realpath(os.curdir), stderr)
+
+                self._root_path = stdout.strip()
+            else:
+                root_path = os.path.expandvars(root_path)
+                root_path = os.path.expanduser(root_path)
+                root_path = os.path.normpath(root_path)
+                self._root_path = os.path.realpath(root_path)
 
         if cache is not None:
             cache = os.path.expandvars(cache)

--- a/fzsl/ui.py
+++ b/fzsl/ui.py
@@ -240,7 +240,8 @@ class SimplePager(object):
                 self._draw_prompt()
 
         try:
-            return self._fm.top_matches(self._max_y)[self._selection]
+            match = self._fm.top_matches(self._max_y)[self._selection]
+            return self._scanner.transform(match)
         except IndexError:
             return ''
 


### PR DESCRIPTION
The idea here is to allow scanners to show a simplified or otherwise different pattern to the user for matching which can be tranformed later.  The demostrated use-case is showing paths relative to the root of a git clone but transforming them to a full path later on.

@jdowner would you mind reviewing this?  It should support your gist use-case as well where you want to present the gist descriptions but use the sha.