### PR TITLE
Use tox to perform virtualenv testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 fzsl.egg-info/
 dist/
 installed_files.txt
+.tox/*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 SHELL = /bin/bash
 
 PYTHON_VERSION ?= $(shell python -c 'import sys;print("%d.%d" % (sys.version_info[0], sys.version_info[1]))')
-VIRTUALENV ?= /usr/bin/env virtualenv
 
 ACTIVATE = source virtualenv$(PYTHON_VERSION)/bin/activate
 REQUIREMENTS = $(shell cat requirements.txt)
@@ -32,17 +31,10 @@ uninstall:
 		rm -f installed_files.txt; \
 	fi
 
-virtualenv$(PYTHON_VERSION): requirements.txt
-	@$(VIRTUALENV) --python=python$(PYTHON_VERSION) virtualenv$(PYTHON_VERSION)
-	@if [ -n "$(REQUIREMENTS)" ]; then \
-		$(ACTIVATE); pip install $(REQUIREMENTS); \
-	fi
-
-test: virtualenv$(PYTHON_VERSION)
+test:
 	@failed=""; \
 	for test in $(TESTS); do \
 		echo "Testing $${test#*_}"; \
-		$(ACTIVATE); \
 		python $${test} --verbose; \
 		if [ $$? -ne 0 ]; then \
 			failed+=" $${test}"; \

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py2,py3
+
+[testenv]
+deps = six
+whitelist_externals = make
+commands = make test


### PR DESCRIPTION
This change replaces the custom code in the Makefile with tox. To run the tests you just need to invoke,
```
$ tox
```
from the top level. It will create a .tox directory (if necessary) and create virtual environments for the specified versions of python. I have add generic versions py2 and py3 since having version 2.x and 3.x seems reasonable for most developers, but having specific versions, e.g. py34, might be annoying.